### PR TITLE
MB886: use XHDPI

### DIFF
--- a/products/pa_mb886.mk
+++ b/products/pa_mb886.mk
@@ -16,10 +16,10 @@
 ifeq (pa_mb886,$(TARGET_PRODUCT))
 
 # Define PA bootanimation size
-PARANOID_BOOTANIMATION_NAME := HDPI
+PARANOID_BOOTANIMATION_NAME := XHDPI
 
 # OVERLAY_TARGET adds overlay asset source
-OVERLAY_TARGET := pa_hdpi
+OVERLAY_TARGET := pa_xhdpi
 
 # Build paprefs from sources
 PREFS_FROM_SOURCE ?= false


### PR DESCRIPTION
Atrix HD is an XHDPI device so it needs to use the XHDPI overlays and boot animation.
